### PR TITLE
Update documentation for a static IPV4 address via nmcli

### DIFF
--- a/Documentation/network.md
+++ b/Documentation/network.md
@@ -97,6 +97,36 @@ If you have trouble with powersave you can do following:
 # Values are 0 (use default), 1 (ignore/don't touch), 2 (disable) or 3 (enable).
 powersave=0
 ```
+## Using nmcli to set a static IPV4 address
+
+this method has been tested with a Hass.io image on an Esxi server. Log into the HASSOS base system via a console – note this is not the same as an SSH login via the add-on.
+```
+Welcome to HassOS
+Hassio login:
+```
+Login as `root` (no password needed)
+
+At the `hassio >` prompt, type `login` (as instructed).
+
+From here you will use the `nmcli` configuration tool.
+
+`# nmcli connection show` will list the “HassOS default” connection in use.
+
+`# nmcli con edit “HassOS default”` will put you in a position to edit the connection.
+
+`nmcli> print ipv4` will show you the ipv4 properties of this connection.
+
+To add your static IP address (select 'yes' for manual method);
+```
+nmcli> set ipv4.addresses 192.168.100.10/24
+Do you also want to set 'ipv4.method' to 'manual'? [yes]:
+nmcli> save
+nmcli> exit
+```
+
+If you now view the default connection `cat /etc/NetworkManager/system_connections/default` you should see the method is manual and the address is set.
+
+Doing a `nmcli con reload` does not always work so restart the VM.
 
 [keyfile]: https://developer.gnome.org/NetworkManager/stable/nm-settings.html
 [configuration-usb]: configuration.md


### PR DESCRIPTION
This update documents a method to change to a Static IPV4 address using the NetworkManager CLI (nmcli).

Happy for the formatting to be modified to suit local convention.

I cannot be more specific about how to get into the base OS as I don't know!

Sorry could not pull the repo properly so it is a completely new file.